### PR TITLE
Update internal references from "riverapiframe" to "apiframe"

### DIFF
--- a/apiendpoint/api_endpoint.go
+++ b/apiendpoint/api_endpoint.go
@@ -16,8 +16,8 @@ import (
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
 
-	"github.com/riverqueue/riverapiframe/apierror"
-	"github.com/riverqueue/riverapiframe/internal/validate"
+	"github.com/riverqueue/apiframe/apierror"
+	"github.com/riverqueue/apiframe/internal/validate"
 )
 
 // Endpoint is a struct that should be embedded on an API endpoint, and which

--- a/apiendpoint/api_endpoint_test.go
+++ b/apiendpoint/api_endpoint_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 
+	"github.com/riverqueue/apiframe/apierror"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/riverapiframe/apierror"
 )
 
 func TestMountAndServe(t *testing.T) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,3 @@
-# riverapiframe [![Build Status](https://github.com/riverqueue/riverapiframe/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/riverqueue/riverapiframe/actions)
+# apiframe [![Build Status](https://github.com/riverqueue/apiframe/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/riverqueue/apiframe/actions)
 
 A minimal API framework for various River projects.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/riverqueue/riverapiframe
+module github.com/riverqueue/apiframe
 
 go 1.23.0
 


### PR DESCRIPTION
Corrects a few straggling problems with the rename done in #1. CI still
passed there, so I thought I'd gotten everything, but didn't.