### PR TITLE
cleanly handle http.MaxBytesError for enforcing req payload size 

### DIFF
--- a/apiendpoint/api_endpoint.go
+++ b/apiendpoint/api_endpoint.go
@@ -139,6 +139,10 @@ func executeAPIEndpoint[TReq any, TResp any](w http.ResponseWriter, r *http.Requ
 		if r.Method != http.MethodGet {
 			reqData, err := io.ReadAll(r.Body)
 			if err != nil {
+				var maxBytesErr *http.MaxBytesError
+				if errors.As(err, &maxBytesErr) {
+					return apierror.NewRequestEntityTooLarge("Request entity too large.")
+				}
 				return fmt.Errorf("error reading request body: %w", err)
 			}
 

--- a/apierror/api_error.go
+++ b/apierror/api_error.go
@@ -132,6 +132,23 @@ func NewNotFoundf(format string, a ...any) *NotFound {
 }
 
 //
+// RequestEntityTooLarge
+//
+
+type RequestEntityTooLarge struct { //nolint:errname
+	APIError
+}
+
+func NewRequestEntityTooLarge(message string) *RequestEntityTooLarge {
+	return &RequestEntityTooLarge{
+		APIError: APIError{
+			Message:    message,
+			StatusCode: http.StatusRequestEntityTooLarge,
+		},
+	}
+}
+
+//
 // ServiceUnavailable
 //
 


### PR DESCRIPTION
One more feature building on #4: making it easy to enforce a max request payload size.

If a middleware applies `http.MaxBytesReader` and we encounter an
`*http.MaxBytesError` when reading the request body, return an HTTP 413
with a clean error.

This does not actually have a function for _applying_ a limit, only for
handling those errors when they occur.