### PR TITLE
make raw payload available to ExtractRaw

### DIFF
--- a/apiendpoint/api_endpoint.go
+++ b/apiendpoint/api_endpoint.go
@@ -4,6 +4,7 @@
 package apiendpoint
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -146,6 +147,8 @@ func executeAPIEndpoint[TReq any, TResp any](w http.ResponseWriter, r *http.Requ
 					return apierror.NewBadRequestf("Error unmarshaling request body: %s.", err)
 				}
 			}
+
+			r.Body = io.NopCloser(bytes.NewReader(reqData))
 		}
 
 		if rawExtractor, ok := any(&req).(RawExtractor); ok {


### PR DESCRIPTION
Capture the request payload and reset the http request body so that `ExtractRaw` can still read the original payload if desired. This is useful in situations like validating a request payload against a signature.

To make this work without adding another test endpoint, I switched the `GET` and `POST` endpoints so the former is the one that implements `ExtractRaw` where we can test both a path param and the request body at the same time. I didn't want to have a situation where all of the endpoints implement `ExtractRaw` and we weren't testing the default path.