### PR TITLE
Allow passing a custom validator instance

### DIFF
--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -4,7 +4,6 @@
 package validate
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -12,11 +11,12 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
-// WithRequiredStructEnabled can be removed once validator/v11 is released.
-var validate = validator.New(validator.WithRequiredStructEnabled()) //nolint:gochecknoglobals
+// Default is the package's default validator instance. WithRequiredStructEnabled
+// can be removed once validator/v11 is released.
+var Default = validator.New(validator.WithRequiredStructEnabled()) //nolint:gochecknoglobals
 
 func init() { //nolint:gochecknoinits
-	validate.RegisterTagNameFunc(preferPublicName)
+	Default.RegisterTagNameFunc(preferPublicName)
 }
 
 // PublicFacingMessage builds a complete error message from a validator error
@@ -24,7 +24,7 @@ func init() { //nolint:gochecknoinits
 //
 // I only added a few possible validations to start. We'll probably need to add
 // more as we go and expand our usage.
-func PublicFacingMessage(validatorErr error) string {
+func PublicFacingMessage(v *validator.Validate, validatorErr error) string {
 	var message string
 
 	//nolint:errorlint
@@ -95,13 +95,6 @@ func PublicFacingMessage(validatorErr error) string {
 	}
 
 	return strings.TrimSpace(message)
-}
-
-// StructCtx validates a structs exposed fields, and automatically validates
-// nested structs, unless otherwise specified and also allows passing of
-// context.Context for contextual validation information.
-func StructCtx(ctx context.Context, s any) error {
-	return validate.StructCtx(ctx, s)
 }
 
 // preferPublicName is a validator tag naming function that uses public names

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -4,11 +4,15 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFromValidator(t *testing.T) {
 	t.Parallel()
+
+	validator := validator.New(validator.WithRequiredStructEnabled())
+	validator.RegisterTagNameFunc(preferPublicName)
 
 	// Fields have JSON tags so we can verify those are used over the
 	// property name.
@@ -43,7 +47,7 @@ func TestFromValidator(t *testing.T) {
 
 		testStruct := validTestStruct()
 		testStruct.MaxInt = 1
-		require.Equal(t, "Field `max_int` must be less than or equal to 0.", PublicFacingMessage(validate.Struct(testStruct)))
+		require.Equal(t, "Field `max_int` must be less than or equal to 0.", PublicFacingMessage(validator, validator.Struct(testStruct)))
 	})
 
 	t.Run("MaxSlice", func(t *testing.T) {
@@ -51,7 +55,7 @@ func TestFromValidator(t *testing.T) {
 
 		testStruct := validTestStruct()
 		testStruct.MaxSlice = []string{"1"}
-		require.Equal(t, "Field `max_slice` must contain at most 0 element(s).", PublicFacingMessage(validate.Struct(testStruct)))
+		require.Equal(t, "Field `max_slice` must contain at most 0 element(s).", PublicFacingMessage(validator, validator.Struct(testStruct)))
 	})
 
 	t.Run("MaxString", func(t *testing.T) {
@@ -59,7 +63,7 @@ func TestFromValidator(t *testing.T) {
 
 		testStruct := validTestStruct()
 		testStruct.MaxString = "value"
-		require.Equal(t, "Field `max_string` must be at most 0 character(s) long.", PublicFacingMessage(validate.Struct(testStruct)))
+		require.Equal(t, "Field `max_string` must be at most 0 character(s) long.", PublicFacingMessage(validator, validator.Struct(testStruct)))
 	})
 
 	t.Run("MinInt", func(t *testing.T) {
@@ -67,7 +71,7 @@ func TestFromValidator(t *testing.T) {
 
 		testStruct := validTestStruct()
 		testStruct.MinInt = 0
-		require.Equal(t, "Field `min_int` must be greater or equal to 1.", PublicFacingMessage(validate.Struct(testStruct)))
+		require.Equal(t, "Field `min_int` must be greater or equal to 1.", PublicFacingMessage(validator, validator.Struct(testStruct)))
 	})
 
 	t.Run("MinSlice", func(t *testing.T) {
@@ -75,7 +79,7 @@ func TestFromValidator(t *testing.T) {
 
 		testStruct := validTestStruct()
 		testStruct.MinSlice = nil
-		require.Equal(t, "Field `min_slice` must contain at least 1 element(s).", PublicFacingMessage(validate.Struct(testStruct)))
+		require.Equal(t, "Field `min_slice` must contain at least 1 element(s).", PublicFacingMessage(validator, validator.Struct(testStruct)))
 	})
 
 	t.Run("MinString", func(t *testing.T) {
@@ -83,7 +87,7 @@ func TestFromValidator(t *testing.T) {
 
 		testStruct := validTestStruct()
 		testStruct.MinString = ""
-		require.Equal(t, "Field `min_string` must be at least 1 character(s) long.", PublicFacingMessage(validate.Struct(testStruct)))
+		require.Equal(t, "Field `min_string` must be at least 1 character(s) long.", PublicFacingMessage(validator, validator.Struct(testStruct)))
 	})
 
 	t.Run("OneOf", func(t *testing.T) {
@@ -91,7 +95,7 @@ func TestFromValidator(t *testing.T) {
 
 		testStruct := validTestStruct()
 		testStruct.OneOf = "red"
-		require.Equal(t, "Field `one_of` should be one of the following values: blue green.", PublicFacingMessage(validate.Struct(testStruct)))
+		require.Equal(t, "Field `one_of` should be one of the following values: blue green.", PublicFacingMessage(validator, validator.Struct(testStruct)))
 	})
 
 	t.Run("Required", func(t *testing.T) {
@@ -99,7 +103,7 @@ func TestFromValidator(t *testing.T) {
 
 		testStruct := validTestStruct()
 		testStruct.Required = ""
-		require.Equal(t, "Field `required` is required.", PublicFacingMessage(validate.Struct(testStruct)))
+		require.Equal(t, "Field `required` is required.", PublicFacingMessage(validator, validator.Struct(testStruct)))
 	})
 
 	t.Run("Unsupported", func(t *testing.T) {
@@ -107,7 +111,7 @@ func TestFromValidator(t *testing.T) {
 
 		testStruct := validTestStruct()
 		testStruct.Unsupported = "abc"
-		require.Equal(t, "Validation on field `unsupported` failed on the `e164` tag.", PublicFacingMessage(validate.Struct(testStruct)))
+		require.Equal(t, "Validation on field `unsupported` failed on the `e164` tag.", PublicFacingMessage(validator, validator.Struct(testStruct)))
 	})
 
 	t.Run("MultipleErrors", func(t *testing.T) {
@@ -116,7 +120,7 @@ func TestFromValidator(t *testing.T) {
 		testStruct := validTestStruct()
 		testStruct.MinInt = 0
 		testStruct.Required = ""
-		require.Equal(t, "Field `min_int` must be greater or equal to 1. Field `required` is required.", PublicFacingMessage(validate.Struct(testStruct)))
+		require.Equal(t, "Field `min_int` must be greater or equal to 1. Field `required` is required.", PublicFacingMessage(validator, validator.Struct(testStruct)))
 	})
 }
 


### PR DESCRIPTION
This is a proof of concept which makes it possible to use custom types and validations within the framework. You may not love this if you're wanting to keep the usage of the validation library as an internal implementation detail which could be swapped out, though in its current state (with a global validator variable that's unexported in an internal package) you cannot register custom types _or_ validations.

This PR reworks the internal validation logic so that a customized validator can be provided. This allows for custom types and validations to be registered for use within the framework. Custom validators are passed as part of `MountOpts`.